### PR TITLE
made silvas actually hide from kingpin

### DIFF
--- a/Data-WF/Scripts/Quests.lua
+++ b/Data-WF/Scripts/Quests.lua
@@ -230,17 +230,17 @@ function InternalEndQuest( ubQuest, sSectorX, sSectorY, fUpdateHistory )
 				SetProfileStrategicInsertionData(Profiles.MARIA, 11771)
 				SetProfileStrategicInsertionData(Profiles.ANGEL, 10967)
 			elseif sector_silva == 3 then
-				-- B6
-				AddNPCtoSector (Profiles.MARIA,6,2,0) 
-				AddNPCtoSector (Profiles.ANGEL,6,2,0)
-				SetProfileStrategicInsertionData(Profiles.MARIA, 16867)
-				SetProfileStrategicInsertionData(Profiles.ANGEL, 15906)
+				-- E7
+				AddNPCtoSector (Profiles.MARIA,7,5,0) 
+				AddNPCtoSector (Profiles.ANGEL,7,5,0)
+				SetProfileStrategicInsertionData(Profiles.MARIA, 7597)
+				SetProfileStrategicInsertionData(Profiles.ANGEL, 6160)
 			elseif sector_silva == 4 then
-				-- B8
-				AddNPCtoSector (Profiles.MARIA,8,2,0) 
-				AddNPCtoSector (Profiles.ANGEL,8,2,0)
-				SetProfileStrategicInsertionData(Profiles.MARIA, 12079)
-				SetProfileStrategicInsertionData(Profiles.ANGEL, 12247)
+				-- E9
+				AddNPCtoSector (Profiles.MARIA,9,5,0) 
+				AddNPCtoSector (Profiles.ANGEL,9,5,0)
+				SetProfileStrategicInsertionData(Profiles.MARIA, 11236)
+				SetProfileStrategicInsertionData(Profiles.ANGEL, 11861)
 			elseif sector_silva == 5 then
 				-- B12
 				AddNPCtoSector (Profiles.MARIA,12,2,0) 
@@ -272,9 +272,9 @@ function InternalEndQuest( ubQuest, sSectorX, sSectorY, fUpdateHistory )
 			elseif sector_hunter1 == 2 then
 				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(5, 2) )
 			elseif sector_hunter1 == 3 then
-				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(6, 2) )
+				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(7, 5) )
 			elseif sector_hunter1 == 4 then
-				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(8, 2) )
+				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(9, 5) )
 			elseif sector_hunter1 == 5 then
 				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_1, SECTOR(12, 2) )
 			elseif sector_hunter1 == 6 then
@@ -290,9 +290,9 @@ function InternalEndQuest( ubQuest, sSectorX, sSectorY, fUpdateHistory )
 			elseif sector_hunter2 == 2 then
 				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(5, 2) )
 			elseif sector_hunter2 == 3 then
-				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(6, 2) )
+				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(7, 5) )
 			elseif sector_hunter2 == 4 then
-				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(8, 2) )
+				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(9, 5) )
 			elseif sector_hunter2 == 5 then
 				SetFact(Facts.FACT_BOUNTYHUNTER_SECTOR_2, SECTOR(12, 2) )
 			elseif sector_hunter2 == 6 then

--- a/Data-WF/Scripts/strategicmap.lua
+++ b/Data-WF/Scripts/strategicmap.lua
@@ -651,15 +651,8 @@ function HandleSectorTacticalEntry( sSectorX, sSectorY, bSectorZ, fHasEverBeenPl
 				if ( (CheckFact( Facts.FACT_BOUNTYHUNTER_KILLED_2, 0 ) == true)  ) then
 					hostile = 1
 				end
-				-- B5
-				if 	(sSectorX == 5 and sSectorY == 2) then
-					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			7447,  hostile)
-					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ADMINISTRATOR, 	13000, hostile)
-					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			13032, hostile)
-					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13557, hostile)
-					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19131, hostile)
 				-- B14
-				elseif (sSectorX == 14 and sSectorY == 2) then
+				if (sSectorX == 14 and sSectorY == 2) then
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			7111,  hostile)
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ADMINISTRATOR, 	13000, hostile)
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			12385, hostile)
@@ -679,7 +672,21 @@ function HandleSectorTacticalEntry( sSectorX, sSectorY, bSectorZ, fHasEverBeenPl
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			13031, hostile)
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13557, hostile)
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19291, hostile)
-				-- A11, B6, B8, B12
+				-- E7
+				elseif (sSectorX == 7 and sSectorY == 5) then
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			7447,  hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ADMINISTRATOR, 	12368, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			12716, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			13699, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19291, hostile)
+				-- E9
+				elseif (sSectorX == 9 and sSectorY == 5) then
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			6645,  hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ADMINISTRATOR, 	13000, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			13032, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			14356, hostile)
+					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ELITE, 			19291, hostile)
+				-- A11, B6, B8, B12, E7, E9
 				else
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ARMY, 			7447,  hostile)
 					CreateArmedCivilain(CivGroup.BOUNTYHUNTER_CIV_GROUP, SoldierClass.SOLDIER_CLASS_ADMINISTRATOR, 	13000, hostile)
@@ -1250,8 +1257,8 @@ function GetIntelAndQuestMapData( aLevel )
 			-- list all possible sectors where Maria & Angel might hide
 			SetIntelAndQuestMapDataForSector(11, 1, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
 			SetIntelAndQuestMapDataForSector(5, 2, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
-			SetIntelAndQuestMapDataForSector(6, 2, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
-			SetIntelAndQuestMapDataForSector(8, 2, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
+			SetIntelAndQuestMapDataForSector(7, 5, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
+			SetIntelAndQuestMapDataForSector(9, 5, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
 			SetIntelAndQuestMapDataForSector(12, 2, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
 			SetIntelAndQuestMapDataForSector(14, 2, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")
 			SetIntelAndQuestMapDataForSector(3, 3, -1, MapSymbols.QUESTIONMARK_BLUE, "Kill or protect Angel & Maria", "")


### PR DESCRIPTION
Changed hiding/bounty hunter sectors B5 & B6 to E7 & E9, because:
- too many civs prevent spawning
- hiding admits kingpins goons is unrealistic